### PR TITLE
Use system node for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,12 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+        language_version: system
         types_or: [javascript, json, markdown, html, css, yaml]
         exclude: pnpm-lock.yaml
   - repo: https://github.com/standard/standard
     rev: v17.1.2
     hooks:
       - id: standard
+        language_version: system
         types: [javascript]


### PR DESCRIPTION
## Summary
- use system-installed Node.js for Prettier and Standard hooks

## Testing
- `pnpm format`
- `pnpm lint:fix`
- `pnpm lint`
- `pre-commit run --files src/js/timer.js` *(fails: files were modified by this hook)*

------
https://chatgpt.com/codex/tasks/task_e_6848c5676bf08320973291ae72378a9a