### PR TITLE
Update pre-commit docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-# default_language_version:
-#   node: "22"
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,7 +405,7 @@ The project uses [pre-commit](https://pre-commit.com) framework for automated co
 - **Remote Hooks**: Uses mirrors-prettier and standard repositories for better pre-commit.ci compatibility
 - **Smart Filtering**: Only processes files that Prettier can handle (`.js`, `.json`, `.md`, `.html`, `.css`, `.yml`, `.yaml`)
 - **Exclusions**: Automatically excludes `pnpm-lock.yaml` from formatting to prevent conflicts
-- **Legacy Script**: `scripts/pre-commit.js` (retained for backward compatibility with local development)
+- **Legacy Script**: `scripts/pre-commit.js` (optional helper for local development; the CI uses remote hooks and doesn't depend on Node.js)
 
 #### Hook Workflow
 

--- a/README.md
+++ b/README.md
@@ -150,14 +150,12 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
    pre-commit run --all-files
    ```
 
-   **About pre-commit hooks**: The hooks automatically run `scripts/pre-commit.js` which handles:
+   **About pre-commit hooks**: The hooks use remote Prettier and StandardJS integrations for a Node-free setup:
 
-   - Code formatting with Prettier for supported file types (`.js`, `.json`, `.md`, `.html`, `.css`, `.yml`, `.yaml`)
-   - JavaScript linting and auto-fixing with StandardJS
-   - Smart file filtering (excludes `pnpm-lock.yaml` and unsupported file types)
-   - Cross-platform compatibility (detects pnpm/npm automatically)
-
-   The same checks run automatically on Pull Requests via [pre-commit.ci](https://pre-commit.ci/)
+- Code formatting with Prettier for supported file types (`.js`, `.json`, `.md`, `.html`, `.css`, `.yml`, `.yaml`)
+- JavaScript linting and auto-fixing with StandardJS
+- Automatic fixes for simple issues
+- Works locally and on [pre-commit.ci](https://pre-commit.ci/)
 
 4. Make your changes
 5. Commit your changes (`git commit -m 'Add some amazing feature'`)


### PR DESCRIPTION
## Summary
- update README to describe remote pre-commit hooks
- remove unused default `node` config
- clarify legacy pre-commit script in AGENTS

## Testing
- `pnpm format`
- `pnpm lint:fix`
- `pnpm lint`
- `pnpm test`
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_6848cea7096883209b88489fbe531115