### PR TITLE
Add audio API tone playback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ this.settings = {
 
 - **Duration Controls**: Customizable timer durations
 - **Behavior Options**: Auto-start toggles
-- **Sound Settings**: Enable/disable audio notifications
+- **Sound Settings**: Enable/disable beep notifications
 - **Collapsible Interface**: Hidden by default, toggleable
 
 ### Statistics Section
@@ -495,7 +495,7 @@ pnpm format && pnpm lint:fix && pnpm lint
 
 - Verify sound settings enabled
 - Check browser audio permissions
-- Confirm audio files are accessible
+- Confirm Web Audio API support
 
 ## Future Enhancement Opportunities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,6 @@ pomodoro-timer/
 │   │   ├── timer.js               # Core PomodoroTimer class and logic
 │   │   └── app.js                 # Application utilities, PWA, and initialization
 │   └── assets/
-│       └── sounds/                # Audio notification files
-│           ├── start.mp3          # Timer start sound
-│           └── finish.mp3         # Timer completion sound
 ├── .github/
 │   ├── workflows/
 │   │   └── deploy.yml             # GitHub Actions deployment workflow

--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ pomodoro-timer/
 │   ├── js/
 │   │   ├── app.js                 # Application initialization and utilities
 │   │   └── timer.js               # Core timer logic and UI management
-│   └── assets/
-│       └── sounds/                # Audio files for notifications
-│           ├── start.mp3
-│           └── finish.mp3
 ├── .github/
 │   └── workflows/
 │       └── deploy.yml             # GitHub Actions for automatic deployment

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ pomodoro-timer/
 │   │   └── styles.css             # Modern CSS with variables and animations
 │   ├── js/
 │   │   ├── app.js                 # Application initialization and utilities
+│   │   ├── audio.js               # Tone playback helper
 │   │   └── timer.js               # Core timer logic and UI management
 ├── .github/
 │   └── workflows/
@@ -111,6 +112,14 @@ This technique helps maintain focus and prevents burnout while maximizing produc
 - **Build**: GitHub Actions for CI/CD
 - **Deployment**: GitHub Pages
 - **Package Manager**: pnpm
+
+## 🔊 Sound Notifications
+
+The timer uses a tiny Web Audio API helper to beep when sessions start and finish. `playTone(frequency, duration)` lives in `src/js/audio.js` and keeps a single `AudioContext` instance for efficient playback.
+
+- **Start beep**: 440&nbsp;Hz
+- **Finish beep**: 880&nbsp;Hz
+- Toggle with the "Sound notifications" checkbox in settings.
 
 ## 🌟 Key Highlights
 

--- a/src/assets/sounds/finish.mp3
+++ b/src/assets/sounds/finish.mp3
@@ -1,1 +1,0 @@
-The file /pomodoro-timer/pomodoro-timer/src/assets/sounds/finish.mp3 is an audio file and cannot be generated as text content. You will need to provide the actual MP3 audio file for the timer's finish sound. Please ensure that you have the audio file ready to place in that directory.

--- a/src/assets/sounds/start.mp3
+++ b/src/assets/sounds/start.mp3
@@ -1,1 +1,0 @@
-The file /pomodoro-timer/pomodoro-timer/src/assets/sounds/start.mp3 is an audio file and cannot be generated as text content. You will need to provide the actual MP3 audio file for the timer start sound. Please ensure you have the appropriate audio file saved in that location.

--- a/src/index.html
+++ b/src/index.html
@@ -231,6 +231,7 @@
       </footer>
     </div>
 
+    <script src="js/audio.js"></script>
     <script src="js/timer.js"></script>
     <script src="js/app.js"></script>
   </body>

--- a/src/js/audio.js
+++ b/src/js/audio.js
@@ -16,9 +16,9 @@ function playTone (frequency, duration = 0.3) {
   oscillator.start()
   oscillator.stop(ctx.currentTime + duration)
   oscillator.onended = () => {
-    oscillator.disconnect();
-    gain.disconnect();
-  };
+    oscillator.disconnect()
+    gain.disconnect()
+  }
 }
 
 if (typeof window !== 'undefined') {

--- a/src/js/audio.js
+++ b/src/js/audio.js
@@ -15,6 +15,10 @@ function playTone (frequency, duration = 0.3) {
   gain.connect(ctx.destination)
   oscillator.start()
   oscillator.stop(ctx.currentTime + duration)
+  oscillator.onended = () => {
+    oscillator.disconnect();
+    gain.disconnect();
+  };
 }
 
 if (typeof window !== 'undefined') {

--- a/src/js/audio.js
+++ b/src/js/audio.js
@@ -1,0 +1,26 @@
+function playTone (frequency, duration = 0.3) {
+  if (typeof window === 'undefined') return
+  const AudioContextClass = window.AudioContext || window.webkitAudioContext
+  if (!AudioContextClass) return
+  if (!playTone.ctx) {
+    playTone.ctx = new AudioContextClass()
+  }
+  const ctx = playTone.ctx
+  const oscillator = ctx.createOscillator()
+  const gain = ctx.createGain()
+  oscillator.type = 'sine'
+  oscillator.frequency.value = frequency
+  gain.gain.value = 0.2
+  oscillator.connect(gain)
+  gain.connect(ctx.destination)
+  oscillator.start()
+  oscillator.stop(ctx.currentTime + duration)
+}
+
+if (typeof window !== 'undefined') {
+  window.playTone = playTone
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { playTone }
+}

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1,3 +1,20 @@
+function playTone (frequency, duration = 0.3) {
+  if (typeof window === 'undefined') return
+  const AudioCtx = window.AudioContext || window.webkitAudioContext
+  if (!AudioCtx) return
+  const ctx = new AudioCtx()
+  const oscillator = ctx.createOscillator()
+  const gain = ctx.createGain()
+  oscillator.type = 'sine'
+  oscillator.frequency.value = frequency
+  gain.gain.value = 0.2
+  oscillator.connect(gain)
+  gain.connect(ctx.destination)
+  oscillator.start()
+  oscillator.stop(ctx.currentTime + duration)
+  oscillator.onended = () => ctx.close()
+}
+
 class PomodoroTimer {
   constructor (options = {}) {
     this.state = {
@@ -148,7 +165,7 @@ class PomodoroTimer {
     this.saveStats()
 
     if (this.settings.soundEnabled) {
-      this.playSound('start')
+      playTone(440)
     }
 
     this.intervalId = setInterval(() => {
@@ -198,7 +215,7 @@ class PomodoroTimer {
     clearInterval(this.intervalId)
 
     if (this.settings.soundEnabled) {
-      this.playSound('finish')
+      playTone(880)
     }
 
     // Update stats
@@ -350,16 +367,6 @@ class PomodoroTimer {
     const minutes = this.state.totalFocusTime % 60
     document.getElementById('total-focus-time').textContent =
       `${hours}h ${minutes}m`
-  }
-
-  playSound (type) {
-    try {
-      const audio = new Audio(`assets/sounds/${type}.mp3`)
-      audio.volume = 0.5
-      audio.play().catch((e) => console.log('Could not play sound:', e))
-    } catch (e) {
-      console.log('Sound not available:', e)
-    }
   }
 
   showNotification () {

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1,20 +1,4 @@
-function playTone (frequency, duration = 0.3) {
-  if (typeof window === 'undefined') return
-  const AudioCtx = window.AudioContext || window.webkitAudioContext
-  if (!AudioCtx) return
-  const ctx = new AudioCtx()
-  const oscillator = ctx.createOscillator()
-  const gain = ctx.createGain()
-  oscillator.type = 'sine'
-  oscillator.frequency.value = frequency
-  gain.gain.value = 0.2
-  oscillator.connect(gain)
-  gain.connect(ctx.destination)
-  oscillator.start()
-  oscillator.stop(ctx.currentTime + duration)
-  oscillator.onended = () => ctx.close()
-}
-
+/* global playTone */
 class PomodoroTimer {
   constructor (options = {}) {
     this.state = {

--- a/src/sw.js
+++ b/src/sw.js
@@ -4,6 +4,7 @@ const urlsToCache = [
   '/index.html',
   '/css/styles.css',
   '/js/app.js',
+  '/js/audio.js',
   '/js/timer.js',
   'https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap'
 ]

--- a/src/sw.js
+++ b/src/sw.js
@@ -5,8 +5,6 @@ const urlsToCache = [
   '/css/styles.css',
   '/js/app.js',
   '/js/timer.js',
-  '/assets/sounds/start.mp3',
-  '/assets/sounds/finish.mp3',
   'https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap'
 ]
 

--- a/tests/audio.test.js
+++ b/tests/audio.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { playTone } from '../src/js/audio.js'
+
+describe('playTone helper', () => {
+  let originalWindow
+
+  beforeEach(() => {
+    originalWindow = global.window
+  })
+
+  afterEach(() => {
+    global.window = originalWindow
+    delete playTone.ctx
+  })
+
+  it('does nothing when window is undefined', () => {
+    delete global.window
+    expect(() => playTone(440)).not.toThrow()
+  })
+
+  it('uses AudioContext if available', () => {
+    const oscStart = vi.fn()
+    const oscStop = vi.fn()
+    const oscillator = {
+      connect: vi.fn(),
+      start: oscStart,
+      stop: oscStop,
+      frequency: { value: 0 },
+      type: ''
+    }
+    const gain = { connect: vi.fn(), gain: { value: 0 } }
+    const createOscillator = vi.fn(() => oscillator)
+    const createGain = vi.fn(() => gain)
+    const AudioContextMock = vi.fn(() => ({
+      createOscillator,
+      createGain,
+      destination: {},
+      currentTime: 0
+    }))
+    global.window = { AudioContext: AudioContextMock }
+    expect(() => playTone(330, 0.1)).not.toThrow()
+    expect(createOscillator).toHaveBeenCalled()
+    expect(oscStart).toHaveBeenCalled()
+    expect(oscStop).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- implement `playTone` using Web Audio API
- beep with `playTone` when timer starts/finishes
- drop `assets/sounds/*.mp3` and remove references
- update service worker and docs

## Testing
- `pnpm format`
- `pnpm lint:fix`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6848d4a7cf8483208fc7c4906e19b47f