### PR TITLE
Add AudioContext mock tests for playTone

### DIFF
--- a/tests/audio.test.js
+++ b/tests/audio.test.js
@@ -10,6 +10,7 @@ describe('playTone helper', () => {
 
   afterEach(() => {
     global.window = originalWindow
+    // ensure a fresh AudioContext for each test
     delete playTone.ctx
   })
 
@@ -37,7 +38,7 @@ describe('playTone helper', () => {
       destination: {},
       currentTime: 0
     }))
-    global.window = { AudioContext: AudioContextMock }
+    global.window = { ...global.window, AudioContext: AudioContextMock }
     expect(() => playTone(330, 0.1)).not.toThrow()
     expect(createOscillator).toHaveBeenCalled()
     expect(oscStart).toHaveBeenCalled()

--- a/tests/timer.test.js
+++ b/tests/timer.test.js
@@ -14,6 +14,7 @@ describe('PomodoroTimer core logic', () => {
 
   afterEach(() => {
     global.window = originalWindow
+    // clear cached AudioContext so each test starts fresh
     delete playTone.ctx
   })
 
@@ -58,7 +59,7 @@ describe('PomodoroTimer core logic', () => {
       destination: {},
       currentTime: 0
     }))
-    global.window = { AudioContext: AudioContextMock }
+    global.window = { ...global.window, AudioContext: AudioContextMock }
     expect(() => playTone(440, 0.1)).not.toThrow()
     expect(createOscillator).toHaveBeenCalled()
     expect(oscStart).toHaveBeenCalled()

--- a/tests/timer.test.js
+++ b/tests/timer.test.js
@@ -1,12 +1,20 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import PomodoroTimer from '../src/js/timer.js'
+import { playTone } from '../src/js/audio.js'
 
 describe('PomodoroTimer core logic', () => {
+  let originalWindow
   beforeEach(() => {
+    originalWindow = global.window
     global.localStorage = {
       setItem: vi.fn(),
       getItem: vi.fn()
     }
+  })
+
+  afterEach(() => {
+    global.window = originalWindow
+    delete playTone.ctx
   })
 
   it('returns correct duration for each mode', () => {
@@ -29,5 +37,31 @@ describe('PomodoroTimer core logic', () => {
     expect(timer.state.mode).toBe('shortBreak')
     expect(timer.state.remainingTime).toBe(10 * 60)
     expect(timer.state.totalTime).toBe(10 * 60)
+  })
+
+  it('playTone creates and runs oscillator', () => {
+    const oscStart = vi.fn()
+    const oscStop = vi.fn()
+    const oscillator = {
+      connect: vi.fn(),
+      start: oscStart,
+      stop: oscStop,
+      frequency: { value: 0 },
+      type: ''
+    }
+    const gain = { connect: vi.fn(), gain: { value: 0 } }
+    const createOscillator = vi.fn(() => oscillator)
+    const createGain = vi.fn(() => gain)
+    const AudioContextMock = vi.fn(() => ({
+      createOscillator,
+      createGain,
+      destination: {},
+      currentTime: 0
+    }))
+    global.window = { AudioContext: AudioContextMock }
+    expect(() => playTone(440, 0.1)).not.toThrow()
+    expect(createOscillator).toHaveBeenCalled()
+    expect(oscStart).toHaveBeenCalled()
+    expect(oscStop).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- expand timer test suite with AudioContext mocking
- verify oscillator start/stop when playTone runs

## Testing
- `pnpm format`
- `pnpm lint:fix`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6848d9f53a048320a349460815fabafe