### PR TITLE
Fix timer resume after reload

### DIFF
--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -129,6 +129,12 @@ class PomodoroTimer {
       this.saveSettings()
     })
 
+    if (typeof window !== 'undefined') {
+      window.addEventListener('beforeunload', () => {
+        this.saveStats()
+      })
+    }
+
     // Keyboard shortcuts
     document.addEventListener('keydown', (e) => {
       if (e.code === 'Space' && !e.target.matches('input')) {
@@ -452,12 +458,16 @@ class PomodoroTimer {
         this.state.isRunning = stats.isRunning || false
         this.state.isPaused = stats.isPaused || false
 
-        if (stats.lastUpdated && this.state.isRunning && !this.state.isPaused) {
-          const elapsed = Math.floor((Date.now() - stats.lastUpdated) / 1000)
-          this.state.remainingTime -= elapsed
-          if (this.state.remainingTime <= 0) {
-            this.state.remainingTime = 0
-            this.complete()
+        if (this.state.isRunning && !this.state.isPaused) {
+          if (stats.lastUpdated) {
+            const elapsed = Math.floor((Date.now() - stats.lastUpdated) / 1000)
+            this.state.remainingTime -= elapsed
+            if (this.state.remainingTime <= 0) {
+              this.state.remainingTime = 0
+              this.complete()
+            } else {
+              resume = true
+            }
           } else {
             resume = true
           }

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1,5 +1,4 @@
 /* global playTone */
-let beforeUnloadHandler = null
 class PomodoroTimer {
   constructor (options = {}) {
     this.state = {
@@ -27,6 +26,7 @@ class PomodoroTimer {
     this.progressRing = null
     this.circumference = 0
     this.saveTimeout = null
+    this.beforeUnloadHandler = null
 
     if (!options.skipInit) {
       this.init()
@@ -131,13 +131,13 @@ class PomodoroTimer {
     })
 
     if (typeof window !== 'undefined') {
-      if (beforeUnloadHandler) {
-        window.removeEventListener('beforeunload', beforeUnloadHandler)
+      if (this.beforeUnloadHandler) {
+        window.removeEventListener('beforeunload', this.beforeUnloadHandler)
       }
-      beforeUnloadHandler = () => {
+      this.beforeUnloadHandler = () => {
         this.saveStats()
       }
-      window.addEventListener('beforeunload', beforeUnloadHandler)
+      window.addEventListener('beforeunload', this.beforeUnloadHandler)
     }
 
     // Keyboard shortcuts

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1,4 +1,5 @@
 /* global playTone */
+let beforeUnloadHandler = null
 class PomodoroTimer {
   constructor (options = {}) {
     this.state = {
@@ -130,9 +131,13 @@ class PomodoroTimer {
     })
 
     if (typeof window !== 'undefined') {
-      window.addEventListener('beforeunload', () => {
+      if (beforeUnloadHandler) {
+        window.removeEventListener('beforeunload', beforeUnloadHandler)
+      }
+      beforeUnloadHandler = () => {
         this.saveStats()
-      })
+      }
+      window.addEventListener('beforeunload', beforeUnloadHandler)
     }
 
     // Keyboard shortcuts

--- a/tests/timer-resume.test.js
+++ b/tests/timer-resume.test.js
@@ -1,0 +1,53 @@
+import { describe, it, beforeEach, expect, vi } from 'vitest'
+import PomodoroTimer from '../src/js/timer.js'
+
+function setupDOM () {
+  const ring = { style: {}, r: { baseVal: { value: 50 } } }
+  document.body.innerHTML = `
+    <div id="timer-display"></div>
+    <div id="current-mode"></div>
+    <div id="session-count"></div>
+    <button id="start-button"><span class="btn-text"></span><span class="btn-icon"></span></button>
+    <button id="pause-button"></button>
+    <button id="reset-button"></button>
+    <div id="completed-sessions"></div>
+    <div id="total-focus-time"></div>
+    <input id="focus-duration" />
+    <input id="short-break-duration" />
+    <input id="long-break-duration" />
+    <input id="long-break-interval" />
+    <input id="auto-start-breaks" type="checkbox" />
+    <input id="auto-start-focus" type="checkbox" />
+    <input id="sound-enabled" type="checkbox" />
+  `
+  vi.spyOn(document, 'querySelector').mockImplementation((sel) => {
+    if (sel === '.progress-ring__progress') return ring
+    return document.body.querySelector(sel)
+  })
+}
+
+describe('PomodoroTimer resume on reload', () => {
+  beforeEach(() => {
+    setupDOM()
+    const today = new Date().toDateString()
+    global.localStorage = {
+      setItem: vi.fn(),
+      getItem: vi.fn(() =>
+        JSON.stringify({
+          date: today,
+          remainingTime: 1500,
+          totalTime: 1500,
+          isRunning: true,
+          isPaused: false
+        })
+      )
+    }
+    global.playTone = vi.fn()
+  })
+
+  it('returns true to resume when lastUpdated is missing', () => {
+    const timer = new PomodoroTimer({ skipInit: true })
+    const resume = timer.loadStats()
+    expect(resume).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure pomodoro stats are saved before unloading the page
- resume countdown even if `lastUpdated` is missing in saved stats
- test resume behavior when reloading

## Testing
- `pnpm format`
- `pnpm lint:fix`
- `pnpm lint`
- `pnpm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6848e8b0c1708320b12baa4cd9f91ac1