### PR TITLE
Fix auto-start behavior and add e2e tests

### DIFF
--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -228,8 +228,8 @@ class PomodoroTimer {
     // Show notification
     this.showNotification()
 
-    // Auto-advance to next mode
-    this.advanceMode()
+    // Auto-advance to next mode after short delay for notification visibility
+    setTimeout(() => this.advanceMode(), 1000)
   }
 
   advanceMode () {
@@ -245,7 +245,7 @@ class PomodoroTimer {
       }
 
       if (this.settings.autoStartBreaks) {
-        setTimeout(() => this.start(), 1000)
+        this.start()
       }
     } else {
       // Coming back from any break
@@ -253,7 +253,7 @@ class PomodoroTimer {
       this.setMode('focus')
 
       if (this.settings.autoStartFocus) {
-        setTimeout(() => this.start(), 1000)
+        this.start()
       }
     }
   }

--- a/tests/auto-start.test.js
+++ b/tests/auto-start.test.js
@@ -1,0 +1,79 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'
+import PomodoroTimer from '../src/js/timer.js'
+
+function setupDOM () {
+  document.body.innerHTML = `
+    <div id="timer-display"></div>
+    <div id="current-mode"></div>
+    <div id="session-count"></div>
+    <button id="start-button"><span class="btn-text"></span><span class="btn-icon"></span></button>
+    <button id="pause-button"></button>
+    <button id="reset-button"></button>
+    <div id="completed-sessions"></div>
+    <div id="total-focus-time"></div>
+  `
+}
+
+let originalLocalStorage
+
+beforeEach(() => {
+  setupDOM()
+  originalLocalStorage = global.localStorage
+  global.localStorage = { setItem: vi.fn(), getItem: vi.fn() }
+  global.playTone = vi.fn()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  global.localStorage = originalLocalStorage
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('auto start behaviour on completion', () => {
+  function createTimer () {
+    const timer = new PomodoroTimer({ skipInit: true })
+    timer.updateUI = () => {}
+    timer.updateProgress = () => {}
+    return timer
+  }
+
+  it('starts break one second after focus completes', () => {
+    const timer = createTimer()
+    timer.settings.autoStartBreaks = true
+    timer.state.remainingTime = 1
+    timer.start()
+    vi.advanceTimersByTime(1000)
+    expect(timer.state.mode).toBe('focus')
+    expect(timer.state.isRunning).toBe(false)
+
+    // still not running before delay has passed
+    vi.advanceTimersByTime(999)
+    expect(timer.state.isRunning).toBe(false)
+
+    vi.advanceTimersByTime(1)
+    expect(timer.state.mode).toBe('shortBreak')
+    expect(timer.state.isRunning).toBe(true)
+    expect(timer.state.remainingTime).toBe(timer.settings.shortBreakDuration * 60)
+  })
+
+  it('starts focus one second after break completes', () => {
+    const timer = createTimer()
+    timer.settings.autoStartFocus = true
+    timer.state.mode = 'shortBreak'
+    timer.settings.shortBreakDuration = 1
+    timer.state.remainingTime = 1
+    timer.start()
+    vi.advanceTimersByTime(1000)
+    expect(timer.state.mode).toBe('shortBreak')
+    expect(timer.state.isRunning).toBe(false)
+
+    vi.advanceTimersByTime(999)
+    expect(timer.state.isRunning).toBe(false)
+
+    vi.advanceTimersByTime(1)
+    expect(timer.state.mode).toBe('focus')
+    expect(timer.state.isRunning).toBe(true)
+    expect(timer.state.remainingTime).toBe(timer.settings.focusDuration * 60)
+  })
+})

--- a/tests/timer-advanced.test.js
+++ b/tests/timer-advanced.test.js
@@ -1,14 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import PomodoroTimer from '../src/js/timer.js'
 
 describe('PomodoroTimer advanced', () => {
+  let originalLocalStorage
+
   beforeEach(() => {
+    originalLocalStorage = global.localStorage
     global.localStorage = { setItem: vi.fn(), getItem: vi.fn() }
+  })
+
+  afterEach(() => {
+    global.localStorage = originalLocalStorage
+    vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   it('advanceMode cycles correctly', () => {
     const timer = new PomodoroTimer({ skipInit: true })
     timer.updateUI = () => {}
+    timer.settings.autoStartBreaks = false
+    timer.settings.autoStartFocus = false
     timer.state.completedSessions = 3
     timer.settings.longBreakInterval = 4
     timer.advanceMode()
@@ -34,5 +45,44 @@ describe('PomodoroTimer advanced', () => {
     const timer2 = new PomodoroTimer({ skipInit: true })
     timer2.loadStats()
     expect(timer2.state.completedSessions).toBe(2)
+  })
+
+  it('auto-starts break synchronously when enabled', () => {
+    vi.useFakeTimers()
+    const timer = new PomodoroTimer({ skipInit: true })
+    timer.updateUI = () => {}
+    const startSpy = vi.spyOn(timer, 'start').mockImplementation(() => {})
+    timer.state.mode = 'focus'
+    timer.settings.autoStartBreaks = true
+    timer.advanceMode()
+    expect(startSpy).toHaveBeenCalled()
+  })
+
+  it('auto-starts focus synchronously when enabled', () => {
+    vi.useFakeTimers()
+    const timer = new PomodoroTimer({ skipInit: true })
+    timer.updateUI = () => {}
+    const startSpy = vi.spyOn(timer, 'start').mockImplementation(() => {})
+    timer.state.mode = 'shortBreak'
+    timer.settings.autoStartFocus = true
+    timer.advanceMode()
+    expect(startSpy).toHaveBeenCalled()
+  })
+
+  it('delays advancing after completion', () => {
+    vi.useFakeTimers()
+    const timer = new PomodoroTimer({ skipInit: true })
+    timer.updateUI = () => {}
+    timer.saveStats = vi.fn()
+    timer.showNotification = vi.fn()
+    timer.clearScheduledSave = vi.fn()
+    global.playTone = vi.fn()
+    vi.spyOn(timer, 'advanceMode')
+    timer.complete()
+    expect(timer.advanceMode).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(999)
+    expect(timer.advanceMode).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(timer.advanceMode).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- auto start breaks/focus instantly
- delay advanceMode call in `complete()` so notifications are visible
- restore `localStorage` mocks in advanced tests
- add `auto-start.test.js` covering delayed start of next session

## Testing
- `pnpm format`
- `pnpm lint:fix`
- `pnpm lint`
- `pnpm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6848ef9b9d7883209414a17b0f2438ad