### PR TITLE
Improve auto-start workflow

### DIFF
--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -228,8 +228,10 @@ class PomodoroTimer {
     // Show notification
     this.showNotification()
 
-    // Auto-advance to next mode
-    this.advanceMode()
+    // Auto-advance to next mode after short delay
+    setTimeout(() => {
+      this.advanceMode()
+    }, 1000)
   }
 
   advanceMode () {
@@ -245,7 +247,7 @@ class PomodoroTimer {
       }
 
       if (this.settings.autoStartBreaks) {
-        setTimeout(() => this.start(), 1000)
+        this.start()
       }
     } else {
       // Coming back from any break
@@ -253,7 +255,7 @@ class PomodoroTimer {
       this.setMode('focus')
 
       if (this.settings.autoStartFocus) {
-        setTimeout(() => this.start(), 1000)
+        this.start()
       }
     }
   }

--- a/tests/auto-start.test.js
+++ b/tests/auto-start.test.js
@@ -36,7 +36,7 @@ describe('PomodoroTimer auto start', () => {
     timer.state.remainingTime = 1
     timer.start()
     vi.advanceTimersByTime(1000)
-    expect(timer.state.mode).toBe('shortBreak')
+    expect(timer.state.mode).toBe('focus')
     expect(timer.state.isRunning).toBe(false)
     vi.advanceTimersByTime(1000)
     expect(timer.state.isRunning).toBe(true)
@@ -53,7 +53,7 @@ describe('PomodoroTimer auto start', () => {
     timer.state.remainingTime = 1
     timer.start()
     vi.advanceTimersByTime(1000)
-    expect(timer.state.mode).toBe('focus')
+    expect(timer.state.mode).toBe('shortBreak')
     expect(timer.state.isRunning).toBe(false)
     vi.advanceTimersByTime(1000)
     expect(timer.state.isRunning).toBe(true)

--- a/tests/timer-advanced.test.js
+++ b/tests/timer-advanced.test.js
@@ -4,6 +4,7 @@ import PomodoroTimer from '../src/js/timer.js'
 describe('PomodoroTimer advanced', () => {
   beforeEach(() => {
     global.localStorage = { setItem: vi.fn(), getItem: vi.fn() }
+    global.playTone = vi.fn()
   })
 
   it('advanceMode cycles correctly', () => {


### PR DESCRIPTION
## Summary
- delay auto-advance inside `complete`
- make `advanceMode` start synchronously when auto-start is enabled
- adjust auto-start tests for new timing
- stub `playTone` in advanced mode tests

## Testing
- `pnpm format`
- `pnpm lint:fix`
- `pnpm lint`
- `pnpm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6848f2aef69083209e56db075689cac3