### PR TITLE
Replace emojis with actual icons in web interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "bun run --hot src/js/app.ts",
     "dev": "http-server src -p 3000 -o",
-    "build": "bun build src/js/app.ts --outdir=dist/js --target=browser && cp -r src/css dist/ && cp src/index.html dist/ && cp src/manifest.json dist/ && cp src/sw.ts dist/sw.js",
+    "build": "bun build src/js/icons.ts --outdir=dist/js --target=browser && bun build src/js/audio.ts --outdir=dist/js --target=browser && bun build src/js/timer.ts --outdir=dist/js --target=browser && bun build src/js/app.ts --outdir=dist/js --target=browser && cp -r src/css dist/ && cp src/index.html dist/ && cp src/manifest.json dist/ && cp src/sw.ts dist/sw.js",
     "preview": "http-server dist -p 3000 -o",
     "format": "prettier --write \"src/**/*.{ts,html,css,json}\" \"*.{ts,json,md}\" --ignore-path .gitignore",
     "lint": "tsc --noEmit",
@@ -47,5 +47,8 @@
     "prettier-config-standard": "^7.0.0",
     "typescript": "^5.9.3",
     "vitest": "~4.0.8"
+  },
+  "dependencies": {
+    "lucide": "^0.553.0"
   }
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -260,6 +260,9 @@ body {
 
 .btn-icon {
   font-size: 1.1rem;
+  width: 20px;
+  height: 20px;
+  stroke-width: 2.5;
 }
 
 /* Settings Section */

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -275,6 +275,13 @@ body {
   margin-bottom: 1rem;
 }
 
+.settings-icon {
+  width: 18px;
+  height: 18px;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+
 .settings-btn {
   background: var(--background);
   border: none;

--- a/src/index.html
+++ b/src/index.html
@@ -108,7 +108,7 @@
 
           <div class="controls">
             <button id="start-button" class="btn btn-primary">
-              <span class="btn-icon">▶</span>
+              <i data-lucide="play" class="btn-icon"></i>
               <span class="btn-text">Start</span>
             </button>
             <button
@@ -116,11 +116,11 @@
               class="btn btn-secondary"
               style="display: none"
             >
-              <span class="btn-icon">⏸</span>
+              <i data-lucide="pause" class="btn-icon"></i>
               <span class="btn-text">Pause</span>
             </button>
             <button id="reset-button" class="btn btn-outline">
-              <span class="btn-icon">↻</span>
+              <i data-lucide="rotate-ccw" class="btn-icon"></i>
               <span class="btn-text">Reset</span>
             </button>
           </div>
@@ -129,7 +129,7 @@
         <div class="settings-section">
           <div class="settings-toggle">
             <button id="settings-toggle-btn" class="settings-btn">
-              ⚙️ Settings
+              <i data-lucide="settings" style="width: 18px; height: 18px; vertical-align: middle; margin-right: 6px;"></i>Settings
             </button>
           </div>
 
@@ -227,10 +227,10 @@
       </main>
 
       <footer class="footer">
-        <p>Built with ❤️ for productivity enthusiasts</p>
       </footer>
     </div>
 
+    <script src="js/icons.js"></script>
     <script src="js/audio.js"></script>
     <script src="js/timer.js"></script>
     <script src="js/app.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -129,16 +129,8 @@
         <div class="settings-section">
           <div class="settings-toggle">
             <button id="settings-toggle-btn" class="settings-btn">
-              <i
-                data-lucide="settings"
-                style="
-                  width: 18px;
-                  height: 18px;
-                  vertical-align: middle;
-                  margin-right: 6px;
-                "
-              ></i
-              >Settings
+              <i data-lucide="settings" class="settings-icon"></i>
+              Settings
             </button>
           </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -226,8 +226,6 @@
           </div>
         </div>
       </main>
-
-      <footer class="footer"></footer>
     </div>
 
     <script src="js/icons.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -129,7 +129,16 @@
         <div class="settings-section">
           <div class="settings-toggle">
             <button id="settings-toggle-btn" class="settings-btn">
-              <i data-lucide="settings" style="width: 18px; height: 18px; vertical-align: middle; margin-right: 6px;"></i>Settings
+              <i
+                data-lucide="settings"
+                style="
+                  width: 18px;
+                  height: 18px;
+                  vertical-align: middle;
+                  margin-right: 6px;
+                "
+              ></i
+              >Settings
             </button>
           </div>
 
@@ -226,8 +235,7 @@
         </div>
       </main>
 
-      <footer class="footer">
-      </footer>
+      <footer class="footer"></footer>
     </div>
 
     <script src="js/icons.js"></script>

--- a/src/js/icons.ts
+++ b/src/js/icons.ts
@@ -1,12 +1,5 @@
 // Icon initialization using Lucide
-import {
-  createIcons,
-  Play,
-  Pause,
-  RotateCcw,
-  Settings,
-  Timer
-} from 'lucide'
+import { createIcons, Play, Pause, RotateCcw, Settings, Timer } from 'lucide'
 
 export function initializeIcons(): void {
   createIcons({

--- a/src/js/icons.ts
+++ b/src/js/icons.ts
@@ -1,0 +1,28 @@
+// Icon initialization using Lucide
+import {
+  createIcons,
+  Play,
+  Pause,
+  RotateCcw,
+  Settings,
+  Timer
+} from 'lucide'
+
+export function initializeIcons(): void {
+  createIcons({
+    icons: {
+      Play,
+      Pause,
+      RotateCcw,
+      Settings,
+      Timer
+    }
+  })
+}
+
+// Initialize icons when DOM is ready
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    initializeIcons()
+  })
+}

--- a/src/js/timer.ts
+++ b/src/js/timer.ts
@@ -414,14 +414,11 @@ export class PomodoroTimer {
       resetBtn.disabled = false
 
       const btnText = startBtn.querySelector('.btn-text')
-      const btnIcon = startBtn.querySelector('.btn-icon')
 
       if (this.state.isPaused) {
         if (btnText) btnText.textContent = 'Resume'
-        if (btnIcon) btnIcon.textContent = '▶'
       } else {
         if (btnText) btnText.textContent = 'Start'
-        if (btnIcon) btnIcon.textContent = '▶'
       }
     }
   }


### PR DESCRIPTION
- Install Lucide icon library for better visual consistency
- Replace play (▶), pause (⏸), reset (↻), and settings (⚙️) emojis with Lucide icons
- Keep tomato emoji (🍅) for branding as requested
- Remove footer text "Built with ❤️ for productivity enthusiasts"
- Add icons.ts module to initialize Lucide icons
- Update build script to include all TypeScript modules
- Add CSS styling for proper icon display (20px size, 2.5 stroke width)
- Update timer.ts to remove icon text manipulation for button state changes

The web interface now uses professional SVG icons for controls while maintaining the tomato emoji for brand identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UI now displays Lucide icons instead of emoji icons for buttons and controls

* **Style**
  * Enhanced icon sizing and stroke rendering for improved visual clarity

* **Chores**
  * Added lucide icon library dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->