### PR TITLE
Improve accessibility and mobile UX with native dialog and touch-friendly controls

### DIFF
--- a/e2e/pomodoro.spec.ts
+++ b/e2e/pomodoro.spec.ts
@@ -58,14 +58,17 @@ test.describe('Pomodoro Timer E2E', () => {
   test('should open and close settings', async ({ page }) => {
     const settingsButton = page.locator('#settings-toggle-btn')
     const settingsPanel = page.locator('#settings-panel')
+    const closeButton = page.locator('#settings-close-btn')
 
-    // Open settings
+    // Open settings (native <dialog> modal)
     await settingsButton.click()
-    await expect(settingsPanel).toHaveClass(/active/)
+    await expect(settingsPanel).toHaveJSProperty('open', true)
+    await expect(settingsButton).toHaveAttribute('aria-expanded', 'true')
 
-    // Close settings
-    await settingsButton.click()
-    await expect(settingsPanel).not.toHaveClass(/active/)
+    // Close via the dialog's close button (the toggle is behind the backdrop)
+    await closeButton.click()
+    await expect(settingsPanel).toHaveJSProperty('open', false)
+    await expect(settingsButton).toHaveAttribute('aria-expanded', 'false')
   })
 
   test('should apply dark theme based on system preference', async ({
@@ -115,11 +118,11 @@ test.describe('Pomodoro Timer E2E', () => {
     // Press KeyS to open settings
     await page.keyboard.press('KeyS')
     const settingsPanel = page.locator('#settings-panel')
-    await expect(settingsPanel).toHaveClass(/active/)
+    await expect(settingsPanel).toHaveJSProperty('open', true)
 
-    // Press Escape to close settings
+    // Press Escape to close settings (native <dialog> handles Escape)
     await page.keyboard.press('Escape')
-    await expect(settingsPanel).not.toHaveClass(/active/)
+    await expect(settingsPanel).toHaveJSProperty('open', false)
   })
 
   test('should save settings to localStorage', async ({ page }) => {
@@ -161,7 +164,8 @@ test.describe('Pomodoro Timer E2E', () => {
     await settingsButton.click()
     await focusDurationInput.fill('0.1')
     await focusDurationInput.blur()
-    await settingsButton.click()
+    // Close the modal (the toggle is behind the backdrop while it's open)
+    await page.keyboard.press('Escape')
 
     // Start timer
     await startButton.click()

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -28,6 +28,27 @@
   box-sizing: border-box;
 }
 
+/* Visually hidden, but available to assistive tech (e.g. the live region). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Kill the 300ms tap delay / double-tap zoom on interactive controls. */
+button,
+input,
+.btn,
+.settings-btn {
+  touch-action: manipulation;
+}
+
 body {
   font-family:
     'Inter',
@@ -139,6 +160,10 @@ body {
 .progress-ring {
   transform: rotate(-90deg);
   filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.1));
+  /* Scale down on narrow phones so the ring never overflows. The SVG's
+     internal geometry (r=130) is unchanged, so the progress math holds. */
+  width: min(280px, 72vw);
+  height: auto;
 }
 
 .progress-ring__background {
@@ -190,8 +215,10 @@ body {
 .btn {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
   padding: 1rem 1.5rem;
+  min-height: 44px;
   border: none;
   border-radius: var(--border-radius);
   font-size: 1rem;
@@ -219,20 +246,10 @@ body {
   transition: left 0.5s;
 }
 
-.btn:hover::before {
-  left: 100%;
-}
-
 .btn-primary {
   background: var(--primary-color);
   color: white;
   box-shadow: var(--shadow);
-}
-
-.btn-primary:hover {
-  background: var(--primary-hover);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-lg);
 }
 
 .btn-secondary {
@@ -241,21 +258,62 @@ body {
   box-shadow: var(--shadow);
 }
 
-.btn-secondary:hover {
-  background: var(--secondary-hover);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-lg);
-}
-
 .btn-outline {
   background: transparent;
   color: var(--text-primary);
   border: 2px solid var(--border);
 }
 
-.btn-outline:hover {
+/* Tactile press feedback — works on touch, where :hover does not. */
+.btn:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+.btn-primary:active {
+  background: var(--primary-hover);
+}
+
+.btn-secondary:active {
+  background: var(--secondary-hover);
+}
+
+.btn-outline:active {
   background: var(--background);
-  transform: translateY(-2px);
+}
+
+/* Hover effects only where a real pointer can hover, so they don't "stick"
+   after a tap on touch devices. */
+@media (hover: hover) and (pointer: fine) {
+  .btn:hover::before {
+    left: 100%;
+  }
+
+  .btn-primary:hover {
+    background: var(--primary-hover);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .btn-secondary:hover {
+    background: var(--secondary-hover);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .btn-outline:hover {
+    background: var(--background);
+    transform: translateY(-2px);
+  }
+}
+
+/* Visible keyboard focus on all interactive controls. */
+.btn:focus-visible,
+.settings-btn:focus-visible,
+.settings-close:focus-visible,
+.input-group input:focus-visible,
+.option-item input:focus-visible {
+  outline: 3px solid var(--secondary-color);
+  outline-offset: 2px;
 }
 
 .btn-icon {
@@ -283,9 +341,13 @@ body {
 }
 
 .settings-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: var(--background);
   border: none;
   padding: 0.75rem 1.5rem;
+  min-height: 44px;
   border-radius: var(--border-radius);
   cursor: pointer;
   font-size: 0.875rem;
@@ -294,31 +356,121 @@ body {
   transition: var(--transition);
 }
 
-.settings-btn:hover {
-  background: var(--border);
+.settings-btn:active {
+  transform: translateY(1px);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .settings-btn:hover {
+    background: var(--border);
+    color: var(--text-primary);
+  }
+}
+
+/* Settings dialog — centered modal on desktop, bottom sheet on mobile.
+   Uses the native <dialog> element for a free focus trap + Esc handling. */
+.settings-panel {
+  width: min(440px, calc(100vw - 2rem));
+  max-height: min(80vh, 640px);
+  overflow-y: auto;
+  padding: 1.5rem;
+  border: none;
+  border-radius: var(--border-radius-lg);
+  background: var(--surface);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-lg);
+  /* The global `* { margin: 0 }` reset clobbers the UA stylesheet's
+     `margin: auto` that centers a modal <dialog>; restore it here. */
+  inset: 0;
+  margin: auto;
+}
+
+/* Native dialogs are display:none until opened; restore layout when open. */
+.settings-panel[open] {
+  display: block;
+  animation: dialogPop 0.2s ease-out;
+}
+
+.settings-panel::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.settings-title {
+  font-size: 1.25rem;
+  font-weight: 600;
   color: var(--text-primary);
 }
 
-.settings-panel {
-  background: var(--background);
+.settings-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: none;
   border-radius: var(--border-radius);
-  padding: 1.5rem;
-  margin-top: 1rem;
-  display: none;
-  animation: slideDown 0.3s ease-out;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: var(--transition);
 }
 
-.settings-panel.active {
-  display: block;
+.settings-close:active {
+  transform: scale(0.94);
 }
 
-@keyframes slideDown {
+@media (hover: hover) and (pointer: fine) {
+  .settings-close:hover {
+    background: var(--background);
+    color: var(--text-primary);
+  }
+}
+
+.shortcut-hint {
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  text-align: center;
+  line-height: 1.8;
+}
+
+.shortcut-hint kbd {
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.1rem 0.4rem;
+}
+
+@keyframes dialogPop {
   from {
     opacity: 0;
-    transform: translateY(-10px);
+    transform: scale(0.96);
   }
   to {
     opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes sheetUp {
+  from {
+    transform: translateY(100%);
+  }
+  to {
     transform: translateY(0);
   }
 }
@@ -347,6 +499,7 @@ body {
 .input-group input {
   width: 100%;
   padding: 0.75rem;
+  min-height: 44px;
   border: 2px solid var(--border);
   border-radius: var(--border-radius);
   font-size: 1rem;
@@ -420,9 +573,11 @@ body {
   transition: var(--transition);
 }
 
-.stat-item:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow);
+@media (hover: hover) and (pointer: fine) {
+  .stat-item:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow);
+  }
 }
 
 .stat-number {
@@ -436,19 +591,6 @@ body {
   font-size: 0.875rem;
   color: var(--text-secondary);
   font-weight: 500;
-}
-
-/* Footer */
-.footer {
-  background: var(--background);
-  padding: 1.5rem;
-  text-align: center;
-  border-top: 1px solid var(--border);
-}
-
-.footer p {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
 }
 
 /* Responsive Design */
@@ -483,6 +625,21 @@ body {
   .stats-grid {
     grid-template-columns: 1fr;
   }
+
+  /* Settings become a bottom sheet: full-width, pinned to the bottom,
+     within thumb reach, sliding up from the bottom edge. */
+  .settings-panel {
+    width: 100%;
+    max-width: 100%;
+    max-height: 85vh;
+    /* top:auto + bottom:0 pins the sheet to the bottom edge, full width. */
+    margin: auto 0 0 0;
+    border-radius: var(--border-radius-lg) var(--border-radius-lg) 0 0;
+  }
+
+  .settings-panel[open] {
+    animation: sheetUp 0.25s ease-out;
+  }
 }
 
 /* Dark mode support */
@@ -498,5 +655,27 @@ body {
 
   body {
     background: linear-gradient(135deg, #2d3748 0%, #1a202c 100%);
+  }
+}
+
+/* Respect users who ask for reduced motion: drop the shine, lifts, ring
+   tween, dialog/sheet entrance, and toast slide. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .btn:active,
+  .settings-btn:active,
+  .settings-close:active {
+    transform: none;
+  }
+
+  .progress-ring__progress {
+    transition: none;
   }
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -12,6 +12,7 @@
   --text-secondary: #718096;
   --text-muted: #a0aec0;
   --border: #e2e8f0;
+  --ring-track: #dbe2ec;
   --shadow:
     0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   --shadow-lg:
@@ -57,7 +58,7 @@ body {
     'Segoe UI',
     Roboto,
     sans-serif;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(160deg, #fbe9e7 0%, #eef1f5 100%);
   color: var(--text-primary);
   min-height: 100vh;
   line-height: 1.6;
@@ -159,7 +160,6 @@ body {
 
 .progress-ring {
   transform: rotate(-90deg);
-  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.1));
   /* Scale down on narrow phones so the ring never overflows. The SVG's
      internal geometry (r=130) is unchanged, so the progress math holds. */
   width: min(280px, 72vw);
@@ -168,14 +168,14 @@ body {
 
 .progress-ring__background {
   fill: none;
-  stroke: var(--border);
-  stroke-width: 8;
+  stroke: var(--ring-track);
+  stroke-width: 10;
 }
 
 .progress-ring__progress {
   fill: none;
   stroke: var(--primary-color);
-  stroke-width: 8;
+  stroke-width: 10;
   stroke-linecap: round;
   stroke-dasharray: 816.8;
   stroke-dashoffset: 816.8;
@@ -593,37 +593,105 @@ body {
   font-weight: 500;
 }
 
-/* Responsive Design */
+/* Responsive Design — fit the whole core UI within one mobile viewport. */
 @media (max-width: 480px) {
+  body {
+    padding: 0;
+    min-height: 100dvh;
+  }
+
+  /* Full-bleed app shell that fills the screen and lays out as a column. */
   .app {
-    margin: 10px;
-    border-radius: var(--border-radius);
+    margin: 0;
+    min-height: 100dvh;
+    border-radius: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .header {
+    padding: 1rem 1.25rem;
+  }
+
+  .title {
+    font-size: 1.5rem;
+    margin-bottom: 0.1rem;
+  }
+
+  .subtitle {
+    font-size: 0.85rem;
   }
 
   .main {
-    padding: 1.5rem;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 1rem 1.25rem 1.25rem;
+  }
+
+  .timer-section {
+    margin-bottom: 0;
+  }
+
+  .timer-mode {
+    margin-bottom: 0.5rem;
+  }
+
+  .timer-circle {
+    margin: 0.4rem auto;
+  }
+
+  /* Size the ring to the smaller of width/height so it never overflows. */
+  .progress-ring {
+    width: min(60vw, 34vh);
   }
 
   .timer-display {
-    font-size: 2.5rem;
+    font-size: 2.25rem;
   }
 
+  /* Keep Start/Reset on one row to save vertical space. */
   .controls {
-    flex-direction: column;
-    gap: 0.75rem;
+    margin-top: 1rem;
+    gap: 0.6rem;
   }
 
   .btn {
-    width: 100%;
-    justify-content: center;
+    flex: 1;
+    padding: 0.85rem 0.75rem;
+  }
+
+  .settings-section {
+    margin-bottom: 0;
+  }
+
+  .settings-toggle {
+    margin-bottom: 0;
   }
 
   .settings-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
   }
 
-  .stats-grid {
-    grid-template-columns: 1fr;
+  /* Compact stats, pinned to the bottom as a footer so any spare vertical
+     space collapses into one place instead of floating the controls. */
+  .stats-section {
+    margin-bottom: 0;
+    margin-top: auto;
+    padding-top: 1.25rem;
+  }
+
+  .stats-section h3 {
+    font-size: 1rem;
+    margin-bottom: 0.6rem;
+  }
+
+  .stat-item {
+    padding: 0.85rem;
+  }
+
+  .stat-number {
+    font-size: 1.5rem;
   }
 
   /* Settings become a bottom sheet: full-width, pinned to the bottom,
@@ -651,10 +719,17 @@ body {
     --text-secondary: #cbd5e0;
     --text-muted: #a0aec0;
     --border: #4a5568;
+    --ring-track: #5a6884;
   }
 
   body {
-    background: linear-gradient(135deg, #2d3748 0%, #1a202c 100%);
+    background: linear-gradient(160deg, #232c3d 0%, #161b27 100%);
+  }
+
+  /* Calm the header so the warm gradient doesn't clash with the cold slate
+     surface in dark mode. */
+  .header {
+    background: linear-gradient(135deg, #9b2c20, #c0392b);
   }
 }
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -631,6 +631,9 @@ body {
 
   .timer-section {
     margin-bottom: 0;
+    /* Pair with the stats' margin-top:auto below to split the spare space
+       above and below, vertically centering the timer group. */
+    margin-top: auto;
   }
 
   .timer-mode {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -626,14 +626,15 @@ body {
     flex: 1;
     display: flex;
     flex-direction: column;
+    /* Center all the content as one block; `safe` falls back to top-aligned
+       when the screen is too short, so nothing ever clips. */
+    justify-content: safe center;
+    gap: 1.5rem;
     padding: 1rem 1.25rem 1.25rem;
   }
 
   .timer-section {
     margin-bottom: 0;
-    /* Pair with the stats' margin-top:auto below to split the spare space
-       above and below, vertically centering the timer group. */
-    margin-top: auto;
   }
 
   .timer-mode {
@@ -644,9 +645,10 @@ body {
     margin: 0.4rem auto;
   }
 
-  /* Size the ring to the smaller of width/height so it never overflows. */
+  /* Hero ring: bigger of the two viewport axes, capped by height so the
+     whole block still fits on short phones. */
   .progress-ring {
-    width: min(60vw, 34vh);
+    width: min(72vw, 34vh);
   }
 
   .timer-display {
@@ -676,12 +678,9 @@ body {
     grid-template-columns: 1fr 1fr;
   }
 
-  /* Compact stats, pinned to the bottom as a footer so any spare vertical
-     space collapses into one place instead of floating the controls. */
+  /* Compact stats; spacing handled by the column gap above. */
   .stats-section {
     margin-bottom: 0;
-    margin-top: auto;
-    padding-top: 1.25rem;
   }
 
   .stats-section h3 {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -712,6 +712,39 @@ body {
   }
 }
 
+/* Short phones (e.g. 360x640, iPhone SE): tighten spacing and shrink the
+   ring so the whole block — stats included — fits without scrolling. Taller
+   phones (>740px) keep the roomier layout untouched. */
+@media (max-width: 480px) and (max-height: 740px) {
+  .header {
+    padding: 0.75rem 1.25rem;
+  }
+
+  .main {
+    gap: 1rem;
+  }
+
+  .progress-ring {
+    width: min(64vw, 30vh);
+  }
+
+  .timer-mode {
+    margin-bottom: 0.25rem;
+  }
+
+  .controls {
+    margin-top: 0.75rem;
+  }
+
+  .stats-section h3 {
+    margin-bottom: 0.4rem;
+  }
+
+  .stat-item {
+    padding: 0.7rem;
+  }
+}
+
 /* Dark mode support */
 @media (prefers-color-scheme: dark) {
   :root {

--- a/src/index.html
+++ b/src/index.html
@@ -86,7 +86,12 @@
           </div>
 
           <div class="timer-circle">
-            <svg class="progress-ring" width="280" height="280">
+            <svg
+              class="progress-ring"
+              width="280"
+              height="280"
+              aria-hidden="true"
+            >
               <circle
                 class="progress-ring__background"
                 cx="140"
@@ -101,13 +106,35 @@
               ></circle>
             </svg>
             <div class="timer-content">
-              <div id="timer-display" class="timer-display">25:00</div>
+              <div
+                id="timer-display"
+                class="timer-display"
+                role="timer"
+                aria-label="Time remaining"
+              >
+                25:00
+              </div>
               <div id="timer-label" class="timer-label">minutes</div>
             </div>
           </div>
 
+          <!-- Polite live region: announces mode changes and completion to
+               screen readers, not the per-second countdown. -->
+          <div
+            id="timer-status"
+            class="sr-only"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          ></div>
+
           <div class="controls">
-            <button id="start-button" class="btn btn-primary">
+            <button
+              id="start-button"
+              class="btn btn-primary"
+              aria-label="Start timer"
+              aria-keyshortcuts="Space"
+            >
               <i data-lucide="play" class="btn-icon"></i>
               <span class="btn-text">Start</span>
             </button>
@@ -115,11 +142,18 @@
               id="pause-button"
               class="btn btn-secondary"
               style="display: none"
+              aria-label="Pause timer"
+              aria-keyshortcuts="Space"
             >
               <i data-lucide="pause" class="btn-icon"></i>
               <span class="btn-text">Pause</span>
             </button>
-            <button id="reset-button" class="btn btn-outline">
+            <button
+              id="reset-button"
+              class="btn btn-outline"
+              aria-label="Reset timer"
+              aria-keyshortcuts="R"
+            >
               <i data-lucide="rotate-ccw" class="btn-icon"></i>
               <span class="btn-text">Reset</span>
             </button>
@@ -128,13 +162,35 @@
 
         <div class="settings-section">
           <div class="settings-toggle">
-            <button id="settings-toggle-btn" class="settings-btn">
+            <button
+              id="settings-toggle-btn"
+              class="settings-btn"
+              aria-haspopup="dialog"
+              aria-controls="settings-panel"
+              aria-expanded="false"
+              aria-keyshortcuts="S"
+            >
               <i data-lucide="settings" class="settings-icon"></i>
               Settings
             </button>
           </div>
 
-          <div id="settings-panel" class="settings-panel">
+          <dialog
+            id="settings-panel"
+            class="settings-panel"
+            aria-labelledby="settings-title"
+          >
+            <div class="settings-header">
+              <h2 id="settings-title" class="settings-title">Settings</h2>
+              <button
+                id="settings-close-btn"
+                class="settings-close"
+                aria-label="Close settings"
+              >
+                <i data-lucide="x"></i>
+              </button>
+            </div>
+
             <div class="settings-grid">
               <div class="setting-item">
                 <label for="focus-duration">Focus Duration</label>
@@ -145,6 +201,7 @@
                     value="25"
                     min="1"
                     max="60"
+                    inputmode="numeric"
                   />
                   <span class="input-suffix">min</span>
                 </div>
@@ -159,6 +216,7 @@
                     value="5"
                     min="1"
                     max="30"
+                    inputmode="numeric"
                   />
                   <span class="input-suffix">min</span>
                 </div>
@@ -173,6 +231,7 @@
                     value="15"
                     min="1"
                     max="60"
+                    inputmode="numeric"
                   />
                   <span class="input-suffix">min</span>
                 </div>
@@ -187,6 +246,7 @@
                     value="4"
                     min="2"
                     max="10"
+                    inputmode="numeric"
                   />
                   <span class="input-suffix">sessions</span>
                 </div>
@@ -209,7 +269,13 @@
                 <label for="sound-enabled">Sound notifications</label>
               </div>
             </div>
-          </div>
+
+            <p class="shortcut-hint">
+              Shortcuts:
+              <kbd>Space</kbd> start/pause · <kbd>R</kbd> reset ·
+              <kbd>S</kbd> settings · <kbd>Esc</kbd> close
+            </p>
+          </dialog>
         </div>
 
         <div class="stats-section">

--- a/src/index.html
+++ b/src/index.html
@@ -90,6 +90,7 @@
               class="progress-ring"
               width="280"
               height="280"
+              viewBox="0 0 280 280"
               aria-hidden="true"
             >
               <circle

--- a/src/js/app.ts
+++ b/src/js/app.ts
@@ -101,13 +101,39 @@ export class KeyboardShortcuts {
   }
 
   toggleSettings(): void {
-    const settingsPanel = document.getElementById('settings-panel')
-    settingsPanel?.classList.toggle('active')
+    const dialog = document.getElementById(
+      'settings-panel'
+    ) as HTMLDialogElement | null
+    if (!dialog) return
+    const isOpen = dialog.open || dialog.hasAttribute('open')
+    if (isOpen) {
+      this.closeSettings()
+      return
+    }
+    if (typeof dialog.showModal === 'function') {
+      dialog.showModal()
+    } else {
+      // Fallback for engines without <dialog> support (e.g. HappyDOM in tests).
+      dialog.setAttribute('open', '')
+    }
+    document
+      .getElementById('settings-toggle-btn')
+      ?.setAttribute('aria-expanded', 'true')
   }
 
   closeSettings(): void {
-    const settingsPanel = document.getElementById('settings-panel')
-    settingsPanel?.classList.remove('active')
+    const dialog = document.getElementById(
+      'settings-panel'
+    ) as HTMLDialogElement | null
+    if (!dialog) return
+    if (typeof dialog.close === 'function' && dialog.open) {
+      dialog.close()
+    } else {
+      dialog.removeAttribute('open')
+    }
+    document
+      .getElementById('settings-toggle-btn')
+      ?.setAttribute('aria-expanded', 'false')
   }
 }
 

--- a/src/js/icons.ts
+++ b/src/js/icons.ts
@@ -1,5 +1,5 @@
 // Icon initialization using Lucide
-import { createIcons, Play, Pause, RotateCcw, Settings, Timer } from 'lucide'
+import { createIcons, Play, Pause, RotateCcw, Settings, Timer, X } from 'lucide'
 
 export function initializeIcons(): void {
   createIcons({
@@ -8,7 +8,14 @@ export function initializeIcons(): void {
       Pause,
       RotateCcw,
       Settings,
-      Timer
+      Timer,
+      X
+    },
+    // Icons are decorative; their buttons carry accessible names via
+    // aria-label. Hide the SVGs from assistive tech and the tab order.
+    attrs: {
+      'aria-hidden': 'true',
+      focusable: 'false'
     }
   })
 }

--- a/src/js/timer.ts
+++ b/src/js/timer.ts
@@ -50,6 +50,7 @@ export class PomodoroTimer {
   completeTimeout: number | null = null
   transitioning: boolean = false
   beforeUnloadHandler: (() => void) | null = null
+  settingsToastTimeout: number | null = null
 
   constructor(options: TimerOptions = {}) {
     this.state = {
@@ -122,13 +123,35 @@ export class PomodoroTimer {
       .getElementById('reset-button')
       ?.addEventListener('click', () => this.reset())
 
-    // Settings toggle
+    // Settings dialog: toggle button opens/closes; close button and clicks on
+    // the backdrop close it. <dialog> handles Esc and focus-return natively.
     document
       .getElementById('settings-toggle-btn')
       ?.addEventListener('click', () => {
-        const panel = document.getElementById('settings-panel')
-        panel?.classList.toggle('active')
+        if (this.isSettingsOpen()) {
+          this.closeSettings()
+        } else {
+          this.openSettings()
+        }
       })
+
+    document
+      .getElementById('settings-close-btn')
+      ?.addEventListener('click', () => this.closeSettings())
+
+    const settingsDialog = this.getSettingsDialog()
+    // A click whose target is the dialog itself lands on the backdrop/padding,
+    // not the content — treat it as a request to dismiss.
+    settingsDialog?.addEventListener('click', (e) => {
+      if (e.target === settingsDialog) this.closeSettings()
+    })
+    // Keep the toggle's aria-expanded in sync however the dialog is closed
+    // (Esc, backdrop, close button, or the S shortcut).
+    settingsDialog?.addEventListener('close', () => {
+      document
+        .getElementById('settings-toggle-btn')
+        ?.setAttribute('aria-expanded', 'false')
+    })
 
     // Settings inputs
     document
@@ -245,6 +268,7 @@ export class PomodoroTimer {
     }, 1000)
 
     this.updateUI()
+    this.announce(`${this.getModeText()} started`)
   }
 
   pause(): void {
@@ -259,6 +283,7 @@ export class PomodoroTimer {
     this.clearScheduledSave()
     this.saveStats()
     this.updateUI()
+    this.announce('Timer paused')
   }
 
   reset(): void {
@@ -277,6 +302,7 @@ export class PomodoroTimer {
 
     this.saveStats()
     this.updateUI()
+    this.announce(`${this.getModeText()} reset`)
   }
 
   tick(): void {
@@ -310,6 +336,11 @@ export class PomodoroTimer {
 
     // Show notification
     this.showNotification()
+    this.announce(
+      this.state.mode === 'focus'
+        ? 'Focus session complete — time for a break'
+        : 'Break complete — back to focus'
+    )
 
     // Block start/Space until advanceMode() runs, so the just-finished timer
     // can't be restarted during the delay.
@@ -582,6 +613,67 @@ export class PomodoroTimer {
 
   saveSettings(): void {
     localStorage.setItem('pomodoro-settings', JSON.stringify(this.settings))
+    this.notifySettingsSaved()
+  }
+
+  // --- Settings dialog helpers -------------------------------------------
+  // Use the native <dialog> when available; fall back to toggling the `open`
+  // attribute under engines (e.g. HappyDOM in tests) that lack showModal().
+
+  getSettingsDialog(): HTMLDialogElement | null {
+    return document.getElementById('settings-panel') as HTMLDialogElement | null
+  }
+
+  isSettingsOpen(): boolean {
+    const dialog = this.getSettingsDialog()
+    return !!dialog && (dialog.open || dialog.hasAttribute('open'))
+  }
+
+  openSettings(): void {
+    const dialog = this.getSettingsDialog()
+    if (!dialog) return
+    if (typeof dialog.showModal === 'function') {
+      if (!dialog.open) dialog.showModal()
+    } else {
+      dialog.setAttribute('open', '')
+    }
+    document
+      .getElementById('settings-toggle-btn')
+      ?.setAttribute('aria-expanded', 'true')
+  }
+
+  closeSettings(): void {
+    const dialog = this.getSettingsDialog()
+    if (!dialog) return
+    if (typeof dialog.close === 'function' && dialog.open) {
+      dialog.close()
+    } else {
+      dialog.removeAttribute('open')
+    }
+    document
+      .getElementById('settings-toggle-btn')
+      ?.setAttribute('aria-expanded', 'false')
+  }
+
+  // Announce mode changes / completion to screen readers via the polite live
+  // region. Deliberately not used for the per-second countdown.
+  announce(message: string): void {
+    const status = document.getElementById('timer-status')
+    if (status) status.textContent = message
+  }
+
+  // Debounced, non-intrusive confirmation that a setting was persisted. Only
+  // schedules when the toast utility is present (i.e. the real browser app).
+  notifySettingsSaved(): void {
+    const showToast = (window as any).utils?.showToast
+    if (typeof showToast !== 'function') return
+    if (this.settingsToastTimeout !== null) {
+      clearTimeout(this.settingsToastTimeout)
+    }
+    this.settingsToastTimeout = window.setTimeout(() => {
+      this.settingsToastTimeout = null
+      showToast('Settings saved', 'success')
+    }, 500)
   }
 
   loadStats(): { resume: boolean; expired: boolean } {

--- a/tests/keyboard-events.test.ts
+++ b/tests/keyboard-events.test.ts
@@ -75,20 +75,20 @@ describe('KeyboardShortcuts event handling', () => {
 
     // Test the method directly
     shortcuts.toggleSettings()
-    expect(settingsPanel.classList.contains('active')).toBe(true)
+    expect(settingsPanel.hasAttribute('open')).toBe(true)
 
     // Toggle again
     shortcuts.toggleSettings()
-    expect(settingsPanel.classList.contains('active')).toBe(false)
+    expect(settingsPanel.hasAttribute('open')).toBe(false)
   })
 
   it('closes settings when Escape is pressed', () => {
     const settingsPanel = document.getElementById('settings-panel')!
-    settingsPanel.classList.add('active')
+    settingsPanel.setAttribute('open', '')
 
     // Test the method directly
     shortcuts.closeSettings()
-    expect(settingsPanel.classList.contains('active')).toBe(false)
+    expect(settingsPanel.hasAttribute('open')).toBe(false)
   })
 
   it('ignores shortcuts when typing in input fields', () => {
@@ -131,7 +131,7 @@ describe('KeyboardShortcuts event handling', () => {
 
     // Settings should not toggle when typing in textarea
     const settingsPanel = document.getElementById('settings-panel')!
-    expect(settingsPanel.classList.contains('active')).toBe(false)
+    expect(settingsPanel.hasAttribute('open')).toBe(false)
   })
 
   it('ignores shortcuts when typing in select', () => {
@@ -150,12 +150,12 @@ describe('KeyboardShortcuts event handling', () => {
     })
 
     const settingsPanel = document.getElementById('settings-panel')!
-    settingsPanel.classList.add('active')
+    settingsPanel.setAttribute('open', '')
 
     document.dispatchEvent(event)
 
-    // Settings should still be active since shortcut was ignored
-    expect(settingsPanel.classList.contains('active')).toBe(true)
+    // Settings should still be open since shortcut was ignored
+    expect(settingsPanel.hasAttribute('open')).toBe(true)
   })
 
   it('handles missing settings panel gracefully', () => {

--- a/tests/theme-shortcuts.test.ts
+++ b/tests/theme-shortcuts.test.ts
@@ -35,17 +35,17 @@ describe('ThemeManager', () => {
 
 describe('KeyboardShortcuts panel helpers', () => {
   beforeEach(() => {
-    document.body.innerHTML = '<div id="settings-panel" class=""></div>'
+    document.body.innerHTML = '<div id="settings-panel"></div>'
   })
   it('toggles and closes panel', () => {
     const ks = new KeyboardShortcutsCls()
     ks.toggleSettings()
     expect(
-      document.getElementById('settings-panel')!.classList.contains('active')
+      document.getElementById('settings-panel')!.hasAttribute('open')
     ).toBe(true)
     ks.closeSettings()
     expect(
-      document.getElementById('settings-panel')!.classList.contains('active')
+      document.getElementById('settings-panel')!.hasAttribute('open')
     ).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
This PR significantly enhances accessibility and mobile user experience by replacing the custom settings panel with the native HTML `<dialog>` element, implementing proper keyboard focus management, adding screen reader announcements, and optimizing touch interactions throughout the app.

## Key Changes

### Accessibility Improvements
- **Native `<dialog>` element**: Replaced custom `.active` class toggling with semantic `<dialog>` for automatic focus trapping, Escape key handling, and backdrop support
- **Screen reader announcements**: Added a polite live region (`#timer-status`) to announce timer state changes (start, pause, reset, completion) to assistive technology
- **Keyboard focus indicators**: Added visible `focus-visible` outlines (3px solid secondary color) on all interactive controls
- **ARIA attributes**: Enhanced buttons with `aria-label`, `aria-keyshortcuts`, `aria-expanded`, `aria-haspopup`, and `role="timer"` for better semantic meaning
- **Icon accessibility**: Marked decorative SVG icons as `aria-hidden="true"` and `focusable="false"` to prevent them from being announced

### Mobile & Touch Optimization
- **Touch-friendly hit targets**: Ensured all interactive controls have a minimum height of 44px (WCAG touch target size)
- **Touch feedback**: Replaced hover-only visual feedback with `:active` state (scale + translateY) that works on touch devices
- **Responsive layout**: Redesigned mobile layout (≤480px) to use flexbox column layout with full-bleed app shell, fitting core UI within one viewport
- **Responsive ring sizing**: Progress ring now uses `min(280px, 72vw)` with `viewBox` to scale responsively without overflow
- **Bottom sheet on mobile**: Settings dialog becomes a full-width bottom sheet on mobile (with `sheetUp` animation) while remaining centered modal on desktop

### Interaction Refinements
- **Hover media query**: Wrapped all `:hover` effects in `@media (hover: hover) and (pointer: fine)` to prevent "sticky" hover states on touch devices
- **Reduced motion support**: Added `@media (prefers-reduced-motion: reduce)` to disable animations for users who request it
- **Keyboard shortcuts display**: Added a hint section in settings showing available shortcuts (Space, R, S, Esc)
- **Settings save feedback**: Debounced toast notification when settings are persisted (500ms delay to avoid spam)

### Visual & Design Updates
- **Background gradient**: Changed from purple (`#667eea` → `#764ba2`) to warm/cool neutral (`#fbe9e7` → `#eef1f5`) for light mode; updated dark mode to slate (`#232c3d` → `#161b27`)
- **Progress ring styling**: Increased stroke width from 8 to 10, updated track color to new `--ring-track` variable
- **Button styling**: Added `justify-content: center` and removed transform-based hover lifts in favor of touch-friendly `:active` states
- **Settings panel**: Redesigned with header (title + close button), improved spacing, and keyboard shortcut hints

### Code Quality
- **Dialog helper methods**: Added `getSettingsDialog()`, `isSettingsOpen()`, `openSettings()`, `closeSettings()` for consistent dialog management
- **Fallback support**: Dialog methods gracefully fall back to attribute-based toggling for test environments (HappyDOM) that lack `showModal()`
- **Announcement helper**: New `announce()` method centralizes screen reader updates via the live region
- **Settings toast debouncing**: New `notifySettingsSaved()` with timeout tracking to prevent rapid duplicate notifications

### Testing Updates
- Updated E2E tests to check `dialog.open` property instead of `.active` class
- Updated unit tests to use `hasAttribute('open')` instead of `classList.contains('active')`
- Adjusted keyboard event tests to work with native dialog behavior

## Notable Implementation Details
- The global `* { margin: 0 }` reset required restoring `margin: auto` on the modal dialog to center it
- Mobile layout uses `justify-content: safe center` to gracefully fall back to top alignment on very short screens
- Short phones (≤

https://claude.ai/code/session_01Pa55kkuMbU5MMRJnnjZ6zc