### PR TITLE
Fix keyboard shortcut check to guard against non-Element nodes

### DIFF
--- a/src/js/app.ts
+++ b/src/js/app.ts
@@ -73,8 +73,13 @@ export class KeyboardShortcuts {
 
   init(): void {
     document.addEventListener('keydown', (e) => {
-      // Don't trigger shortcuts when typing in inputs
-      if ((e.target as HTMLElement).matches('input, textarea, select')) {
+      // Don't trigger shortcuts when typing in inputs. Guard with `instanceof`
+      // because keydown can target non-Element nodes (e.g. document for
+      // synthetic events), which have no `matches()` — mirrors timer.ts.
+      if (
+        e.target instanceof HTMLElement &&
+        e.target.matches('input, textarea, select')
+      ) {
         return
       }
 


### PR DESCRIPTION
## Summary
Fixed a potential runtime error in the keyboard shortcuts initialization by adding a type guard before calling the `matches()` method on event targets.

## Key Changes
- Added `instanceof HTMLElement` check before calling `matches()` on the event target
- This prevents errors when `keydown` events target non-Element nodes (e.g., document or synthetic events)
- Updated the comment to explain the rationale and reference the similar pattern used in `timer.ts`

## Implementation Details
The `matches()` method is only available on Element nodes. In certain scenarios (particularly with synthetic events), the `keydown` event target may not be an Element, which would cause a runtime error when attempting to call `matches()`. The fix ensures the target is an `HTMLElement` before attempting to use the `matches()` selector method, making the code more robust and consistent with existing patterns in the codebase.